### PR TITLE
Update typed-rest-client version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "semver": "^5.3.0",
     "@types/semver": "^5.3.0",
     "semver-compare": "^1.0.0",
-    "typed-rest-client": "^0.11.0",
+    "typed-rest-client": "0.14.1",
     "uuid": "^3.0.1",
     "@types/uuid": "^3.0.1",
     "vsts-task-lib": "2.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.4.2",
+  "version": "0.5.1",
   "description": "VSTS Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "VSTS Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {


### PR DESCRIPTION
Build and test are passing locally.

We haven't released this in a bit, so this change(obviously :)) and the status code in the exception dictionary haven't been published. When you get a chance if you can publish this and let me know then I can make the changes to reference the new version in vsts-tasks.

I also removed the carat from the typed rest client version, seems better to be explicit.

Thanks!