### PR TITLE
Use typed-rest-client 1.0.7 to allow toolLib.downloadTool to work with redirects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,17 @@ build/Release
 node_modules
 jspm_packages
 
+# Npm lock files
+package-lock.json
+
 # Optional npm cache directory
 .npm
 
 # Optional REPL history
 .node_repl_history
+
+# Temp directories
+TEMP
+
+# Resources
+Strings/*

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,3 @@ package-lock.json
 
 # Temp directories
 TEMP
-
-# Resources
-Strings/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,498 @@
+{
+  "name": "vsts-task-tool-lib",
+  "version": "0.5.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "5.0.35",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+      "dev": true,
+      "requires": {
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "8.9.4"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.4.tgz",
+      "integrity": "sha512-dSvD36qnQs78G1BPsrZFdPpvLgMW/dnvr5+nTW2csMs5TiP9MOXrjUbnMZOEwnIuBklXtn7b6TPA2Cuq07bDHA==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+    },
+    "@types/shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha512-M2giRw93PxKS7YjU6GZjtdV9HASdB7TWqizBXe4Ju7AqbKlWvTr0gNO92XH56D/gMxqD/jNHLNfC5hA34yGqrQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "5.0.35",
+        "@types/node": "8.9.4"
+      }
+    },
+    "@types/uuid": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
+      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "requires": {
+        "@types/node": "9.4.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "9.4.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
+          "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
+        }
+      }
+    },
+    "@types/xml2js": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
+      "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.9.4"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "mockery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node": {
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/node/-/node-8.9.4.tgz",
+      "integrity": "sha512-3/3EJFUgpaS9LpG6EbbdCKLzaXC5RmvBfRzzv/brvHauqoS9YIrxraAxrW2MkL5mviSGp5x9EHQxwFd9Fh8LnA==",
+      "dev": true,
+      "requires": {
+        "node-bin-setup": "1.0.6"
+      }
+    },
+    "node-bin-setup": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
+      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.5.0"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.1",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "tunnel": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+    },
+    "typed-rest-client": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.7.tgz",
+      "integrity": "sha512-0u+4yiprNuCoXzWllWuDB81i5Riyg0nwrMFs9RczRjU0ZzIWG4lodtXNxoBL19Jb9I8qVN/VTBG7x+mR2kvq+A==",
+      "requires": {
+        "tunnel": "0.0.4",
+        "underscore": "1.8.3"
+      }
+    },
+    "typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "vsts-task-lib": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.6.tgz",
+      "integrity": "sha1-9sqGS3sDsS23N8nV/2kThGNpEFY=",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "shelljs": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "semver": "^5.3.0",
     "@types/semver": "^5.3.0",
     "semver-compare": "^1.0.0",
-    "typed-rest-client": "0.14.1",
+    "typed-rest-client": "1.0.7",
     "uuid": "^3.0.1",
     "@types/uuid": "^3.0.1",
     "vsts-task-lib": "2.0.6"

--- a/test/toolTests.ts
+++ b/test/toolTests.ts
@@ -83,80 +83,35 @@ describe('Tool Tests', function () {
 
 
     
-    describe('has status code in exception dictionary for HTTP error code responses', function () {
-        this.timeout(2000);
-        
-        let httpErrorCodes:number[] = [400,401,402,403,404,405,406,407,408,409,410,411,412,413,414,415,416,417,418,422,428,429,431,451,500,501,502,503,504,505,511,520,522,524]
+    it('has status code in exception dictionary for HTTP error code responses', async function() {
+        return new Promise<void>(async(resolve, reject)=> {
+            try {
+                let errorCodeUrl: string = "https://httpbin.org/status/400";
+                let downPath: string = await toolLib.downloadTool(errorCodeUrl);
 
-        for (let errorCodes of httpErrorCodes) {
-            it('error thrown on HTTP status code ' + errorCodes, async function() {
-                return new Promise<void>(async(resolve, reject)=> {
-                    try {
-                        let errorCodeUrl: string = `https://httpbin.org/status/${errorCodes}`;
-                        let downPath: string = await toolLib.downloadTool(errorCodeUrl);
-        
-                        reject('a file was downloaded but it shouldnt have been');
-                    } 
-                    catch (err){
-                        assert.equal(err['httpStatusCode'], errorCodes, 'status code exists');
-        
-                        resolve();
-                    }
-                });
-            });
-        }
+                reject('a file was downloaded but it shouldnt have been');
+            } 
+            catch (err){
+                assert.equal(err['httpStatusCode'], 400, 'status code exists');
 
-
-        
+                resolve();
+            }
+        });
     });
 
-    describe('accepts any status code < 400', function() {
-        this.timeout(2000);
+    it('works with redirect code 302', async function () {
+        return new Promise<void>(async(resolve, reject)=> {
+            try {
+                let statusCodeUrl: string = "https://httpbin.org/redirect-to?url=http%3A%2F%2Fexample.com%2F&status_code=302";
+                let downPath: string = await toolLib.downloadTool(statusCodeUrl);
 
-        let redirectHttpStatusCodes:number[] = [300,301,302,303,304,305,306,307,308]
-
-        for(let redirectStatusCode in redirectHttpStatusCodes) {
-            it('works with redirect code ' + redirectStatusCode, async function () {
-                return new Promise<void>(async(resolve, reject)=> {
-                    try {
-                        let statusCodeUrl: string = `https://httpbin.org/redirect-to?url=http%3A%2F%2Fexample.com%2F&status_code=${redirectStatusCode}`;
-                        let downPath: string = await toolLib.downloadTool(statusCodeUrl);
-        
-                        resolve();
-                    } 
-                    catch (err){        
-                        reject(err);
-                    }
-                });
-            });
-        }
-
-        
-
-        /*
-          Note that HTTP codes 1xx are acceptable as well but https://httpstat.us keeps returning the same 1xx code which leads the request to time out. 
-          In a real world situation an endpoint would at some point return a different HTTP status code.
-        */
-        let acceptableHttpStatusCodes:number[] = [200,201,202,203,204,205,206]
-        
-
-        for (let statusCode of acceptableHttpStatusCodes) {
-            it('accepts HTTP status code ' + statusCode, async function() {
-                return new Promise<void>(async(resolve, reject)=> {
-                    try {
-                        let statusCodeUrl: string = `https://httpbin.org/status/${statusCode}`;
-                        let downPath: string = await toolLib.downloadTool(statusCodeUrl);
-        
-                        resolve();
-                    } 
-                    catch (err){        
-                        reject(err);
-                    }
-                });
-            });
-        }
-        
-    })
+                resolve();
+            } 
+            catch (err){        
+                reject(err);
+            }
+        });
+    });
 
     it('installs a binary tool and finds it', function () {
         this.timeout(2000);

--- a/test/toolTests.ts
+++ b/test/toolTests.ts
@@ -81,26 +81,44 @@ describe('Tool Tests', function () {
         });
     });
 
-    it('has status code in exception dictionary for non 200 response', function () {
+
+    
+    describe('has status code in exception dictionary for HTTP error code responses', function () {
         this.timeout(2000);
+        
+        let httpErrorCodes:number[] = [400,401,402,403,404,405,406,407,408,409,410,411,412,413,414,415,416,417,418,422,428,429,431,451,500,501,502,503,504,505,511,520,522,524,]
 
-        return new Promise<void>(async(resolve, reject)=> {
-            try {
-                let nonExistentUrl: string = "http://httpbin.org/nonexistent";
-                let downPath: string = await toolLib.downloadTool(nonExistentUrl);
+        for (let errorCodes of httpErrorCodes) {
+            it('error thrown on HTTP status code ' + errorCodes, function() {
+                return new Promise<void>(async(resolve, reject)=> {
+                    try {
+                        let errorCodeUrl: string = "https://httpstat.us/" + errorCodes;;
+                        let downPath: string = await toolLib.downloadTool(errorCodeUrl);
+        
+                        reject('a file was downloaded but it shouldnt have been');
+                    } 
+                    catch (err){
+                        assert.equal(err['httpStatusCode'], errorCodes, 'status code exists');
+        
+                        resolve();
+                    }
+                });
+            });
+        }
 
-                reject('a file was downloaded but it shouldnt have been');
-            } 
-            catch (err){
-                assert.equal(err['httpStatusCode'], 404, 'status code exists');
 
-                resolve();
-            }
-        });
+        
     });
 
     describe('accepts any status code < 400', function() {
-        let acceptableHttpStatusCodes:string[] = ["200","201","202","203","204","205","206","300","301","302","303","304","305","306","307","308"]
+        this.timeout(2000);
+
+        /*
+          Note that HTTP codes 1xx are acceptable as well but https://httpstat.us keeps returning the same 1xx code which leads the request to time out. 
+          In a real world situation an endpoint would at some point return a different HTTP status code.
+        */
+        let acceptableHttpStatusCodes:number[] = [200,201,202,203,204,205,206,300,301,302,303,304,305,306,307,308]
+        
 
         for (let statusCode of acceptableHttpStatusCodes) {
             it('accepts HTTP status code ' + statusCode, function() {

--- a/test/toolTests.ts
+++ b/test/toolTests.ts
@@ -86,13 +86,13 @@ describe('Tool Tests', function () {
     describe('has status code in exception dictionary for HTTP error code responses', function () {
         this.timeout(2000);
         
-        let httpErrorCodes:number[] = [400,401,402,403,404,405,406,407,408,409,410,411,412,413,414,415,416,417,418,422,428,429,431,451,500,501,502,503,504,505,511,520,522,524,]
+        let httpErrorCodes:number[] = [400,401,402,403,404,405,406,407,408,409,410,411,412,413,414,415,416,417,418,422,428,429,431,451,500,501,502,503,504,505,511,520,522,524]
 
         for (let errorCodes of httpErrorCodes) {
-            it('error thrown on HTTP status code ' + errorCodes, function() {
+            it('error thrown on HTTP status code ' + errorCodes, async function() {
                 return new Promise<void>(async(resolve, reject)=> {
                     try {
-                        let errorCodeUrl: string = "https://httpstat.us/" + errorCodes;;
+                        let errorCodeUrl: string = `https://httpbin.org/status/${errorCodes}`;
                         let downPath: string = await toolLib.downloadTool(errorCodeUrl);
         
                         reject('a file was downloaded but it shouldnt have been');
@@ -113,25 +113,43 @@ describe('Tool Tests', function () {
     describe('accepts any status code < 400', function() {
         this.timeout(2000);
 
-        /*
-          Note that HTTP codes 1xx are acceptable as well but https://httpstat.us keeps returning the same 1xx code which leads the request to time out. 
-          In a real world situation an endpoint would at some point return a different HTTP status code.
-        */
-        let acceptableHttpStatusCodes:number[] = [200,201,202,203,204,205,206,300,301,302,303,304,305,306,307,308]
-        
+        let redirectHttpStatusCodes:number[] = [300,301,302,303,304,305,306,307,308]
 
-        for (let statusCode of acceptableHttpStatusCodes) {
-            it('accepts HTTP status code ' + statusCode, function() {
+        for(let redirectStatusCode in redirectHttpStatusCodes) {
+            it('works with redirect code ' + redirectStatusCode, async function () {
                 return new Promise<void>(async(resolve, reject)=> {
                     try {
-                        let statusCodeUrl: string = "https://httpstat.us/" + statusCode;
+                        let statusCodeUrl: string = `https://httpbin.org/redirect-to?url=http%3A%2F%2Fexample.com%2F&status_code=${redirectStatusCode}`;
                         let downPath: string = await toolLib.downloadTool(statusCodeUrl);
         
                         resolve();
                     } 
-                    catch (err){
-                        assert.equal(err['httpStatusCode'], 404, 'status code exists');
+                    catch (err){        
+                        reject(err);
+                    }
+                });
+            });
+        }
+
         
+
+        /*
+          Note that HTTP codes 1xx are acceptable as well but https://httpstat.us keeps returning the same 1xx code which leads the request to time out. 
+          In a real world situation an endpoint would at some point return a different HTTP status code.
+        */
+        let acceptableHttpStatusCodes:number[] = [200,201,202,203,204,205,206]
+        
+
+        for (let statusCode of acceptableHttpStatusCodes) {
+            it('accepts HTTP status code ' + statusCode, async function() {
+                return new Promise<void>(async(resolve, reject)=> {
+                    try {
+                        let statusCodeUrl: string = `https://httpbin.org/status/${statusCode}`;
+                        let downPath: string = await toolLib.downloadTool(statusCodeUrl);
+        
+                        resolve();
+                    } 
+                    catch (err){        
                         reject(err);
                     }
                 });

--- a/test/toolTests.ts
+++ b/test/toolTests.ts
@@ -99,6 +99,29 @@ describe('Tool Tests', function () {
         });
     });
 
+    describe('accepts any status code < 400', function() {
+        let acceptableHttpStatusCodes:string[] = ["200","201","202","203","204","205","206","300","301","302","303","304","305","306","307","308"]
+
+        for (let statusCode of acceptableHttpStatusCodes) {
+            it('accepts HTTP status code ' + statusCode, function() {
+                return new Promise<void>(async(resolve, reject)=> {
+                    try {
+                        let statusCodeUrl: string = "https://httpstat.us/" + statusCode;
+                        let downPath: string = await toolLib.downloadTool(statusCodeUrl);
+        
+                        resolve();
+                    } 
+                    catch (err){
+                        assert.equal(err['httpStatusCode'], 404, 'status code exists');
+        
+                        reject(err);
+                    }
+                });
+            });
+        }
+        
+    })
+
     it('installs a binary tool and finds it', function () {
         this.timeout(2000);
 

--- a/tool.ts
+++ b/tool.ts
@@ -222,7 +222,7 @@ export async function downloadTool(url: string, fileName?: string): Promise<stri
             // TODO: retries
             tl.debug('downloading');
             let response: httpm.HttpClientResponse = await http.get(url);
-            if (response.message.statusCode != 200) {
+            if (response.message.statusCode >= 400) {
                 let err: Error = new Error('Unexpected HTTP response: ' + response.message.statusCode);
                 err['httpStatusCode'] = response.message.statusCode;
                 tl.debug(`Failed to download "${fileName}" from "${url}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`);

--- a/tool.ts
+++ b/tool.ts
@@ -222,7 +222,7 @@ export async function downloadTool(url: string, fileName?: string): Promise<stri
             // TODO: retries
             tl.debug('downloading');
             let response: httpm.HttpClientResponse = await http.get(url);
-            if (response.message.statusCode >= 400) {
+            if (response.message.statusCode != 200) {
                 let err: Error = new Error('Unexpected HTTP response: ' + response.message.statusCode);
                 err['httpStatusCode'] = response.message.statusCode;
                 tl.debug(`Failed to download "${fileName}" from "${url}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`);


### PR DESCRIPTION
# Background
While trying to download a tools exe from Github releases using toolLib.downloadTool I got the following error: UnhandledPromiseRejectionWarning: Error: Unexpected HTTP response: 302. Github was redirecting met to an AWS blob which seems perfectly fine to me but toolLib.downloadTool only accepts HTTP 200.

# Change
I updated typed-rest-client to 1.0.7 to allow toolLib.downloadTool to work with HTTP redirects.
