### PR TITLE
Added option destination directory to the extractTar and extractZip methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "VSTS Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "VSTS Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/tool.ts
+++ b/tool.ts
@@ -486,7 +486,10 @@ function _createExtractFolder(dest?: string): string {
         dest = path.join(_getAgentTemp(), uuidV4());
     }
 
-    tl.mkdirP(dest);
+    if (!tl.exist(dest)) {
+        tl.mkdirP(dest);
+    }
+    
     return dest;
 }
 

--- a/tool.ts
+++ b/tool.ts
@@ -486,9 +486,7 @@ function _createExtractFolder(dest?: string): string {
         dest = path.join(_getAgentTemp(), uuidV4());
     }
 
-    if (!tl.exist(dest)) {
-        tl.mkdirP(dest);
-    }
+    tl.mkdirP(dest);
     
     return dest;
 }

--- a/tool.ts
+++ b/tool.ts
@@ -429,14 +429,15 @@ export async function extract7z(file: string, dest?: string, _7zPath?: string): 
  * @param version   version of the tool
  * @param arch      arch of the tool.  optional.  defaults to the arch of the machine
  * @param options   IExtractOptions
+ * @param destination   destination directory. optional.
  */
-export async function extractTar(file: string): Promise<string> {
+export async function extractTar(file: string, destination?: string): Promise<string> {
 
     // mkdir -p node/4.7.0/x64
     // tar xzC ./node/4.7.0/x64 -f node-v4.7.0-darwin-x64.tar.gz --strip-components 1
 
     console.log(tl.loc('TOOL_LIB_ExtractingArchive'));
-    let dest = _createExtractFolder();
+    let dest = _createExtractFolder(destination);
 
     let tr: trm.ToolRunner = tl.tool('tar');
     tr.arg(['xzC', dest, '-f', file]);
@@ -445,13 +446,13 @@ export async function extractTar(file: string): Promise<string> {
     return dest;
 }
 
-export async function extractZip(file: string): Promise<string> {
+export async function extractZip(file: string, destination?: string): Promise<string> {
     if (!file) {
         throw new Error("parameter 'file' is required");
     }
 
     console.log(tl.loc('TOOL_LIB_ExtractingArchive'));
-    let dest = _createExtractFolder();
+    let dest = _createExtractFolder(destination);
 
     if (process.platform == 'win32') {
         // build the powershell command


### PR DESCRIPTION
Added option destination directory to the extractTar and extractZip methods.  This allows for vsts-tasks build tasks to use these methods when a specific destination directory needs to be specified.

Ran npm tests and verified on azure vm.