### PR TITLE
Update typed-rest-client to 1.0.9, and add unittest to cover 303 case.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -413,9 +413,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.7.tgz",
-      "integrity": "sha512-0u+4yiprNuCoXzWllWuDB81i5Riyg0nwrMFs9RczRjU0ZzIWG4lodtXNxoBL19Jb9I8qVN/VTBG7x+mR2kvq+A==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+      "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "semver": "^5.3.0",
     "@types/semver": "^5.3.0",
     "semver-compare": "^1.0.0",
-    "typed-rest-client": "1.0.7",
+    "typed-rest-client": "1.0.9",
     "uuid": "^3.0.1",
     "@types/uuid": "^3.0.1",
     "vsts-task-lib": "2.4.0"

--- a/test/toolTests.ts
+++ b/test/toolTests.ts
@@ -66,7 +66,28 @@ describe('Tool Tests', function () {
 
         return new Promise<void>(async (resolve, reject) => {
             try {
-                let downPath: string = await toolLib.downloadTool("https://httpbin.org/redirect-to?url=http%3A%2F%2Fhttpbin.org%2Fbytes%2F100&status_code=302");
+                
+                let downPath: string = await toolLib.downloadTool("https://httpbin.org/redirect-to?url=" + encodeURI('http://httpbin.org/bytes/100') + "&status_code=302");
+                toolLib.debug('downloaded path: ' + downPath);
+
+                assert(tl.exist(downPath), 'downloaded file exists');
+                assert.equal(fs.statSync(downPath).size, 100, 'downloaded file is the correct size');
+
+                resolve();
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    });
+
+    it('downloads a 100 byte file after a redirect 303 (See Other)', function () {
+        this.timeout(5000);
+
+        return new Promise<void>(async (resolve, reject) => {
+            try {
+                
+                let downPath: string = await toolLib.downloadTool("https://httpbin.org/redirect-to?url=" + encodeURI('http://httpbin.org/bytes/100') + "&status_code=303");
                 toolLib.debug('downloaded path: ' + downPath);
 
                 assert(tl.exist(downPath), 'downloaded file exists');

--- a/tool.ts
+++ b/tool.ts
@@ -183,7 +183,6 @@ export function findLocalToolVersions(toolName: string, arch?: string) {
 
 //
 // TODO: keep extension intact
-// TODO: support 302 redirect
 //
 /**
  * Download a tool from an url and stream it into a file


### PR DESCRIPTION
Could you please update the typed-rest-client to 1.0.9 so it could handle redirection with status code 303?