### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10929: Build ID 31481860

### DIFF
--- a/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Strings/resources.resjson/fr-FR/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.messages.TOOL_LIB_CachingTool": "Mise en cache de l’outil : %s %s %s",
   "loc.messages.TOOL_LIB_Downloading": "Téléchargement : %s",
-  "loc.messages.TOOL_LIB_ExtractingArchive": "Extraction de l’archive",
+  "loc.messages.TOOL_LIB_ExtractingArchive": "Extraction de l'archive",
   "loc.messages.TOOL_LIB_FoundInCache": "Outil trouvé dans le cache : %s %s %s",
   "loc.messages.TOOL_LIB_PrependPath": "Préfixation de la variable d’environnement PATH avec le répertoire : %s"
 }

--- a/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.messages.TOOL_LIB_CachingTool": "Средство кэширования: %s %s %s",
-  "loc.messages.TOOL_LIB_Downloading": "Скачивание: %s",
-  "loc.messages.TOOL_LIB_ExtractingArchive": "Идет распаковка архива",
+  "loc.messages.TOOL_LIB_Downloading": "Идет скачивание: %s.",
+  "loc.messages.TOOL_LIB_ExtractingArchive": "Идет распаковка архива.",
   "loc.messages.TOOL_LIB_FoundInCache": "Найдено средство в кэше: %s %s %s",
   "loc.messages.TOOL_LIB_PrependPath": "Перед переменной окружения PATH добавляется каталог: %s"
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.